### PR TITLE
Add http methods as operations to resource

### DIFF
--- a/wso2/discovery/api/Resource.proto
+++ b/wso2/discovery/api/Resource.proto
@@ -16,7 +16,7 @@ option java_multiple_files = true;
 message Resource {
     string id = 1;
 	string path = 2;
-	repeated string methods = 3;
+	repeated Operation methods = 3;
 	string summary = 4;
 	string description = 5;
 	repeated Endpoint productionUrls = 6;
@@ -26,4 +26,20 @@ message Resource {
 	repeated string consumes = 10;
 	repeated string schemes = 11;
 	repeated string tags = 12;
+}
+
+// Operation model which maps to a particular http methods
+message Operation {
+    string method = 1;
+    repeated SecurityList security = 2;
+}
+
+// Holds the array of security schemas defined for particular API operation
+message SecurityList {
+    map<string, Scopes> scopeList = 1;
+}
+
+// Holds the list of scopes belongs to a particular security schema
+message Scopes {
+    repeated string scopes = 1;
 }


### PR DESCRIPTION
Earlier the http methods was included as a string array in the resources proto. 
But swagger security is in the operation level(method) level not in the path level. Hence modified the resource proto to add operations